### PR TITLE
ClassNotFoundException: clojure.set

### DIFF
--- a/src/leiningen/midje.clj
+++ b/src/leiningen/midje.clj
@@ -87,5 +87,5 @@
                      (require-namespaces-form desired-namespaces)
                      nil
                      nil
-                     '(require '[clojure walk template stacktrace test string]))))
+                     '(require '[clojure walk template stacktrace test string set]))))
                      


### PR DESCRIPTION
same as [Midje Issue 49](/marick/Midje/issues/49), but the root cause lies here in lein-midje

The explanation for this is simple, clojure.set is no longer loaded at startup since Clojure 1.3, see also [ChangeLog for Clojure 1.3](clojure/clojure/blob/1.3.x/changes.txt#L65)

To fix it I simply added the set namespace to init parameter of eval-in-project.
