### PR TITLE
Remove bundled bultitude code

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,4 @@
   :description "Run Midje and clojure.test tests"
   :url "https://github.com/marick/lein-midje"
   :eval-in-leiningen true
-  :dependencies [[bultitude "0.1.3"]]
   :dev-dependencies [[midje "1.3.0"]])


### PR DESCRIPTION
- in lein 1 use old utilities for namespace lookup
- in lein 2 use bultitude. It is included in lein 2
