### PR TITLE
fix wildcards for leiningen 1

### DIFF
--- a/src/leiningen/midje.clj
+++ b/src/leiningen/midje.clj
@@ -114,7 +114,7 @@
      (bultitude.core/namespaces-on-classpath :prefix prefix))
    (do
      (require ['leiningen.util.ns])
-     (leiningen.util.ns/namespaces-matching prefix))))
+     (leiningen.util.ns/namespaces-matching (.replaceAll prefix "-" "_")))))
 
 (defn- get-namespaces [namespaces]
   (mapcat #(if (= \* (last %))


### PR DESCRIPTION
As discussed some time ago, here's the quick fix for prefix-based midje runs: 

```
lein1 midje ns-with-dash.*
```

Leiningen 2 has the issue too: I've submitted a pull request for the fix in raynes/bultitude. That will fix the issue there without hacks.
