### PR TITLE
Fixed installation instructions for Leiningen 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,15 @@ Installation
 `lein-midje` is available as a plugin:
 
       $ lein plugin install lein-midje 1.0.10  ;; Leiningen 1
-      
-      $ lein plugin install lein-midje 2.0.0-SNAPSHOT  ;; Leiningen 2
 
 [Note: for reasons unknown, you may need to first uninstall
 earlier versions.]
 
 Or you can include it in your `project.clj`:
 
-      :dev-dependencies [[lein-midje "1.0.10"]]) ;; Leiningen 1
+      :dev-dependencies [[lein-midje "1.0.10"]] ;; Leiningen 1
       
-      :dev-dependencies [[lein-midje "2.0.0-SNAPSHOT"]]) ;; Leiningen 2
+      :profiles {:dev {:plugins [[lein-midje "2.0.0-SNAPSHOT"]]}} ;; Leiningen 2
 
 
 Use


### PR DESCRIPTION
The installation instructions for Leiningen 2 were outdated. In Leiningen 2, there's no install plugin, and dev-dependencies have been replaced by profiles.
