### PR TITLE
generate foo-bar.core namespace in new projects instead of foo_bar.core

### DIFF
--- a/src/leiningen/new/midje/core.clj
+++ b/src/leiningen/new/midje/core.clj
@@ -1,4 +1,4 @@
-(ns {{sanitized}}.core)
+(ns {{name}}.core)
 
 ;;; This is an incorrect implementation, such as might be written by
 ;;; someone who was used to a Lisp in which an empty list is equal to
@@ -7,4 +7,3 @@
   (if (nil? sequence)
     default
     (first sequence)))
-

--- a/src/leiningen/new/midje/t_core.clj
+++ b/src/leiningen/new/midje/t_core.clj
@@ -1,6 +1,6 @@
-(ns {{sanitized}}.t-core
+(ns {{name}}.t-core
   (:use midje.sweet)
-  (:use [{{sanitized}}.core]))
+  (:use [{{name}}.core]))
 
 (facts "about `first-element`"
   (fact "it normally returns the first element"


### PR DESCRIPTION
This is how lein new foo-bar would do it.
