### PR TITLE
Testfiles default name should be consistent with lein.

### DIFF
--- a/src/leiningen/new/midje.clj
+++ b/src/leiningen/new/midje.clj
@@ -28,7 +28,7 @@
       ["project.clj" (render "project.clj" data)]
       ["README.md" (render "README.md" data)]
       ["src/{{sanitized}}/core.clj" (render "core.clj" data)]
-      ["test/{{sanitized}}/t_core.clj" (render "t_core.clj" data)])))
+      ["test/{{sanitized}}/core_test.clj" (render "core_test.clj" data)])))
 
 (defn midje
   "Creates a template project for doing TDD with Clojure."

--- a/src/leiningen/new/midje/core_test.clj
+++ b/src/leiningen/new/midje/core_test.clj
@@ -1,4 +1,4 @@
-(ns {{name}}.t-core
+(ns {{name}}.core-test
   (:use midje.sweet)
   (:use [{{name}}.core]))
 


### PR DESCRIPTION
Change the default naming of test files to: `"test/{{sanitized}}/core_test.clj"`.

This is to be compatible with both Leiningen naming and clojure-test-mode.
`clojure-jump-between-tests-and-code` should work again.
