### PR TITLE
Use Leiningen's Exit Semantics

### DIFF
--- a/src/leiningen/midje.clj
+++ b/src/leiningen/midje.clj
@@ -14,9 +14,10 @@
 (defn make-load-facts-form [namespace-strings filters]
   (let [true-namespaces (map (fn [nss] `(quote ~(symbol nss)))
                              namespace-strings)]
-    `(System/exit (min 255
-                       (:failures (midje.repl/load-facts ~@true-namespaces
-                                                         ~@(repl-style-filters filters)))))))
+    `(let [failures# (:failures (midje.repl/load-facts ~@true-namespaces
+                                                       ~@(repl-style-filters filters)))]
+       (when-not (zero? failures#) 
+         (main/exit 255)))))
 
 (defn make-autotest-form [dirs filters]
   ;; Note: filters with an empty arglist means "use the default".


### PR DESCRIPTION
lein-midje is currently using `System/exit` after it's done (with status 255 in case of error and 0 otherwise). This breaks higher-order tasks (like `do`) which rely on `leiningen.core.main/exit`'s behaviour to surpress termination of the process if desired. For example:

```
$ lein do version, midje
Leiningen 2.2.0 on Java 1.7.0_25 Java HotSpot(TM) 64-Bit Server VM
All checks (9) succeeded.

$ lein do midje, version
All checks (9) succeeded.
```

This commit makes lein-midje only call `exit` in case of failure:

```
$ lein do midje, version
All checks (9) succeeded.
Leiningen 2.2.0 on Java 1.7.0_25 Java HotSpot(TM) 64-Bit Server VM
```
