### PR TITLE
Remove reference to leiningen.core.main; fix small typo in core_test

### DIFF
--- a/src/leiningen/midje.clj
+++ b/src/leiningen/midje.clj
@@ -2,8 +2,7 @@
 
 (ns leiningen.midje
   (:use [leiningen.core.eval :only [eval-in-project]])
-  (:require [leiningen.core.main :as main]
-            [clojure.set :as set]))
+  (:require [clojure.set :as set]))
 
 (defn repl-style-filters [filters]
   (map #(if (= (first %) \-)
@@ -14,10 +13,9 @@
 (defn make-load-facts-form [namespace-strings filters]
   (let [true-namespaces (map (fn [nss] `(quote ~(symbol nss)))
                              namespace-strings)]
-    `(let [failures# (:failures (midje.repl/load-facts ~@true-namespaces
-                                                       ~@(repl-style-filters filters)))]
-       (when-not (zero? failures#) 
-         (main/exit 255)))))
+    `(System/exit (min 255
+                       (:failures (midje.repl/load-facts ~@true-namespaces
+                                                         ~@(repl-style-filters filters)))))))
 
 (defn make-autotest-form [dirs filters]
   ;; Note: filters with an empty arglist means "use the default".
@@ -73,12 +71,12 @@
 
 (defn parse-args [arglist]
   (let [arglist-segments (partition-by flag? arglist)]
-      
+
       {:true-args (flag-args arglist-segments)
        :autotest? (any? autotest-segment? arglist-segments)
        :config? (any? config-segment? arglist-segments)
        :filter? (any? filter-segment? arglist-segments)
-       
+
        :autotest-args (autotest-args arglist-segments)
        :config-args (config-args arglist-segments)
        :filter-args (filter-args arglist-segments)}))
@@ -115,8 +113,8 @@
 
 
   ** Autotest
-  
-  % lein midje :autotest 
+
+  % lein midje :autotest
   % lein midje :autotest test/midje/util src/midje/util
 
   Starts a repl, uses `midje.repl`, and runs `(autotest)`.  The result

--- a/src/leiningen/new/midje/core_test.clj
+++ b/src/leiningen/new/midje/core_test.clj
@@ -2,7 +2,7 @@
   (:use midje.sweet)
   (:use [{{name}}.core]))
 
-(println "You sbould expect to see three failures below.")
+(println "You should expect to see three failures below.")
 
 (facts "about `first-element`"
   (fact "it normally returns the first element"


### PR DESCRIPTION
Implements the version of make-load-facts-form in 1dca9695, but keeps all of the subsequent 3.1.2 tweaks.

This version uses System/exit and removes the reference to leiningen.core.main in the ns. I'm falling back on [your discussion with technomancy](http://librelist.com/browser/leiningen/2013/1/1/why-can-t-i-get-at-leiningen-core-main/#32f5dcaf5b235ff87b944205da775623) in January for why use of System/exit should be OK.

This patch also addresses a small typo in core_test.
