### PR TITLE
Correct Exit Code Generation (fix #43)

### DIFF
--- a/test/lein_midje/t_lein_midje.clj
+++ b/test/lein_midje/t_lein_midje.clj
@@ -76,5 +76,5 @@
       result => #"set-config-files!.*\[\"config.1\"\s+\"config.2\"\]")))
 
 (fact :metadata "filters passed in"
-  (pr-str (make-load-facts-form [] ["integration" "-slow"]))
+  (pr-str (make-load-facts-form {} [] ["integration" "-slow"]))
   => #"load-facts :integration \(clojure.core/complement :slow\)")


### PR DESCRIPTION
See [this comment](https://github.com/marick/lein-midje/issues/43#issuecomment-25747508). 

This uses `leiningen.core.main/exit` if a project's map contains `:eval-in :leiningen` or `:eval-in-leiningen true`, and `System/exit` otherwise. Also, the respective exit function is only called if there really are any failures and the maximum exit code is restored to 255.

This means that the plugin now exits correctly in both cases while also offering the possibility to be run within another plugin's context, producing an examinable error code contained in an exception thrown in case of failures.

Again, sorry for breaking the plugin. I hope this fixes the issue, leaving only the small typo corrections to be pulled from #44.
