### PR TITLE
Added explicit lein dependency in install section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,18 @@ Installation
 `lein-midje` is a plugin, so add this to your
 `~/.lein/profiles.clj`:
 
-    {:user {:plugins [[lein-midje "3.1.1"]]}}
+    {:user {:plugins [[lein-midje "3.1.3"]]}}
 
 Or you can include it in your `project.clj`:
 
-    {:profiles {:dev {:plugins [[lein-midje "3.1.1"]]}}}
+    {:profiles {:dev {:plugins [[lein-midje "3.1.3"]]}}}
+
+`lein-midje` depends on `midje` itself. If you don't already have `midje` in your `project.clj`, you'll need to add it.
+For example, you could use this in place of the profiles above:
+
+    {:profiles {:dev {:dependencies [[midje "1.6.0" :exclusions [org.clojure/clojure]]]
+                      :plugins [[lein-midje "3.1.3"]]}}}
+
 
 Use
 ==========


### PR DESCRIPTION
The installation instructions in the readme.md file don’t explicitly say to add midje to the project dependencies. Just starting out with lein-midje, I stumbled around quite a bit trying to get it installed. I added a mention of this dependency to the installation section along with an alternative :profile that works in the case where someone has not yet added a dependency on midje. (Credit where due, I found the solution here: http://stackoverflow.com/tags/leiningen/new
Anyhow, there may be a better way to do it, but these instructions would have made my first encounter with lein-midje much smoother.
Also, while I was at it, I brought the lein-midje version up to 3.1.3, which seems to be current.
