### PR TITLE
Favor 'require' over 'use'.

### DIFF
--- a/src/leiningen/midje.clj
+++ b/src/leiningen/midje.clj
@@ -1,8 +1,8 @@
 ;; -*- indent-tabs-mode: nil -*-
 
 (ns leiningen.midje
-  (:use [leiningen.core.eval :only [eval-in-project]])
   (:require [leiningen.core.main :as main]
+            [leiningen.core.eval :refer [eval-in-project]]
             [clojure.set :as set]))
 
 (defn repl-style-filters [filters]

--- a/src/leiningen/new/midje/core_test.clj
+++ b/src/leiningen/new/midje/core_test.clj
@@ -1,6 +1,6 @@
 (ns {{name}}.core-test
-  (:use midje.sweet)
-  (:use [{{name}}.core]))
+  (:require [midje.sweet :refer :all]
+            [{{name}}.core :refer :all]))
 
 (println "You should expect to see three failures below.")
 

--- a/src/leiningen/new/midje/midje_file_to_add.clj
+++ b/src/leiningen/new/midje/midje_file_to_add.clj
@@ -1,5 +1,5 @@
 (ns {{sanitized}}.midje
-  (:use [midje.sweet]))
+  (:require [midje.sweet :refer :all]))
 
 (fact (+ 2 2) => 5)
 (fact (+ 2 2) => odd?)

--- a/test/lein_midje/t_lein_midje.clj
+++ b/test/lein_midje/t_lein_midje.clj
@@ -1,6 +1,6 @@
 (ns lein-midje.t-lein-midje
-  (:use midje.sweet
-        leiningen.midje))
+  (:require [midje.sweet :refer :all]
+            [leiningen.midje :refer :all]))
 
 (fact "flags can be parsed from an arglist"
   :has-metadata


### PR DESCRIPTION
It's considered better style to use the various flavors of 'require' over 'use' in ns declarations. I made the changes here. It was initially my intent to change only the files related to the leiningen template, but decided to go for them all.

Thanks for reading and let me know what you think.
