### PR TITLE
lein new midje should generate nested dirs

### DIFF
--- a/src/leiningen/new/midje.clj
+++ b/src/leiningen/new/midje.clj
@@ -13,8 +13,8 @@
            (format "You'll find a sample test file in %s." 
 
                 " Going to add files to make transitioning to Midje easier" "test/{{sanitized}}/midje.clj"))
-  (let [data {:name name :sanitized (new/sanitize name)}
-        paths [["test/{{sanitized}}/midje.clj" (render "midje_file_to_add.clj" data)]]]
+  (let [data {:name name :sanitized (new/sanitize name) :nested-dirs (new/name-to-path main-ns)}
+        paths [["test/{{nested-dirs}}/midje.clj" (render "midje_file_to_add.clj" data)]]]
       (doseq [path paths]
         (let [[path content] path
               path (io/file name (new/render-text path data))]
@@ -23,12 +23,12 @@
 
 (defn- create-new-project [name]
   (println (format "Generating a project called '%s' based on the 'midje' template." (str name)))
-  (let [data {:name name :sanitized (new/sanitize name)}]
+  (let [data {:name name :sanitized (new/sanitize name) :nested-dirs (new/name-to-path main-ns)}]
     (new/->files data
       ["project.clj" (render "project.clj" data)]
       ["README.md" (render "README.md" data)]
-      ["src/{{sanitized}}/core.clj" (render "core.clj" data)]
-      ["test/{{sanitized}}/core_test.clj" (render "core_test.clj" data)])))
+      ["src/{{nested-dirs}}/core.clj" (render "core.clj" data)]
+      ["test/{{nested-dirs}}/core_test.clj" (render "core_test.clj" data)])))
 
 (defn midje
   "Creates a template project for doing TDD with Clojure."


### PR DESCRIPTION
Change the default naming of src files to: "src/{{nested-dirs}}/core.clj".
Change the default naming of test files to: "test/{{nested-dirs}}/core_test.clj".

This should avoid an annoying result as follows, and be consistent with other lein templates AFAK. 
```
$ lein new midje a.b.c
$ lein midje
...
Exception in thread "main" java.io.FileNotFoundException: Could not locate a/b/c/core_test__init.class or a/b/c/core_test.clj on classpath:
...
```