### PR TITLE
Fixed readme to show examples with current versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Installation
 `lein-midje` is a plugin, so add this to your
 `~/.lein/profiles.clj`:
 
-    {:user {:plugins [[lein-midje "3.1.3"]]}}
+    {:user {:plugins [[lein-midje "3.2"]]}}
 
 Or you can include it in your `project.clj`:
 
-    {:profiles {:dev {:plugins [[lein-midje "3.1.3"]]}}}
+    {:profiles {:dev {:plugins [[lein-midje "3.2"]]}}}
 
 `lein-midje` depends on `midje` itself. If you don't already have `midje` in your `project.clj`, you'll need to add it.
 For example, you could use this in place of the profiles above:
 
-    {:profiles {:dev {:dependencies [[midje "1.6.0" :exclusions [org.clojure/clojure]]]
-                      :plugins [[lein-midje "3.1.3"]]}}}
+    {:profiles {:dev {:dependencies [[midje "1.8.3"]]
+                      :plugins [[lein-midje "3.2"]]}}}
 
 
 Use


### PR DESCRIPTION
This confused me for awhile, since the different versions don't have the same profile :midje functionality. This should help people include the correct version in the future and not get confused. 